### PR TITLE
Remove email address from README.md

### DIFF
--- a/esp32/app/ESP32_mqtts_gpio/README.md
+++ b/esp32/app/ESP32_mqtts_gpio/README.md
@@ -12,9 +12,7 @@ test.mosquitto.org (also public) or coudmqtt.com (your private one) or others.
 ## esp-idf used
 * commit fd3ef4cdfe1ce747ef4757205f4bb797b099c9d9
 * Merge: 94a61389 52c378b4
-* Author: Angus Gratton <angus@espressif.com>
 * Date:   Fri Apr 21 12:27:32 2017 +0800
-
 
 ## eclipse
 * include include.xml to C-Paths


### PR DESCRIPTION
Hi,

I'm getting email support requests for this project from people who found my email address published in the README (for the ESP-IDF version in use). I'd appreciate it if you please removed it, it's not necessary for identifying the correct ESP-IDF version.

Thanks,

Angus